### PR TITLE
Add createTransactionAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ The same as generateKeyImage, but allows you to reuse a derivation you have prev
 
 *Documentation In Progress*
 
+#### createTransactionAsync(transfers, ourOutputs, randomOuts, mixin, feeAmount, [paymentId], [unlockTime])
+
+Functions as `createTransaction`, but runs asynchronously, and additionaly, supports user provided async functions.
+The regular code only supports synchronous provided funcs, so ensure any async user provided functions are not being used in other calls you make.
+
 #### serializeTransaction(transaction)
 
 *Documentation In Progress*

--- a/index.d.ts
+++ b/index.d.ts
@@ -187,6 +187,19 @@ export class CryptoNote {
         unlockTime?: number): CreatedTransaction;
 
     /**
+     * Creates a valid transaction to be submitted to the network for sending.
+     * Supports passed in user functions that are asynchronous.
+     */
+    public createTransactionAsync(
+        transfers: TxDestination[],
+        ourOutputs: Output[],
+        randomOuts: RandomOutput[][],
+        mixin: number,
+        feeAmount: number,
+        paymentId?: string,
+        unlockTime?: number): Promise<CreatedTransaction>;
+
+    /**
      * Converts an amount in atomic units, to a human friendly representation.
      */
     public formatMoney(amount: number): string;

--- a/index.js
+++ b/index.js
@@ -580,12 +580,12 @@ class CryptoNote {
     return result
   }
 
-  createTransactionStructure (ourKeys, newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime, _async) {
-    return createTransaction(ourKeys, newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime, _async)
+  createTransactionStructure (newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime, _async) {
+    return createTransaction(newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime, _async)
   }
 
-  createTransaction (ourKeys, newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime) {
-    var tx = this.createTransactionStructure(ourKeys, newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime, false)
+  createTransaction (newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime) {
+    var tx = this.createTransactionStructure(newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime, false)
     var serializedTransaction = serializeTransaction(tx)
     var txnHash = cnFastHash(serializedTransaction)
 
@@ -596,9 +596,9 @@ class CryptoNote {
     }
   }
 
-  createTransactionAsync (ourKeys, newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime) {
+  createTransactionAsync (newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime) {
     return this.createTransactionStructure(
-      ourKeys, newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime, true
+      newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime, true
     ).then((tx) => {
       var serializedTransaction = serializeTransaction(tx)
       var txnHash = cnFastHash(serializedTransaction)
@@ -1050,6 +1050,9 @@ function createTransaction (newOutputs, ourOutputs, randomOutputs, mixin, feeAmo
     throw new Error('ourOutputs must be an array')
   }
 
+  console.log(randomOutputs.length);
+  console.log(ourOutputs.length);
+
   /* Make sure that if we are to use mixins that we've been given the
      correct number of sets of random outputs */
   if (randomOutputs.length !== ourOutputs.length && mixin !== 0) {
@@ -1146,9 +1149,13 @@ function createTransaction (newOutputs, ourOutputs, randomOutputs, mixin, feeAmo
 
   tx.extra = addTransactionPublicKeyToExtra(tx.extra, transactionOutputs.transactionKeys.publicKey)
 
+  console.log('1');
+
   if (_async) {
+    console.log('2');
     return transactionOutputs.outputs.then((outputs) => {
-      outputs.forEeach((output) => {
+      console.log('3');
+      outputs.forEach((output) => {
         tx.vout.push(output)
       })
 
@@ -1167,14 +1174,18 @@ function createTransaction (newOutputs, ourOutputs, randomOutputs, mixin, feeAmo
         var sigPromise = generateRingSignature(
           txPrefixHash, txInput.keyImage, srcKeys, txInput.input.privateEphemeral, txInput.realOutputIndex
         ).then((sigs) => {
+          console.log('4');
           tx.signatures.push(sigs)
         })
+
+        console.log('5');
 
         sigPromises.push(sigPromise)
       }
 
       /* Wait for all the sigs to get created and added, then return the tx */
       return Promise.all(sigPromises).then(() => {
+        console.log('6');
         return tx
       })
     })

--- a/index.js
+++ b/index.js
@@ -596,7 +596,7 @@ class CryptoNote {
     }
   }
 
-  createTransactionAsync (newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime, ) {
+  createTransactionAsync (newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime) {
     return this.createTransactionStructure(
       newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime, true
     ).then((tx) => {
@@ -1308,7 +1308,7 @@ function prepareTransactionOutputs (outputs, _async) {
   outputs.sort((a, b) => (a.amount > b.amount) ? 1 : ((b.amount > a.amount) ? -1 : 0))
 
   const preparedOutputs = []
-  let promises = [];
+  let promises = []
 
   if (_async) {
     promises = outputs.map((output, i) => {
@@ -1321,7 +1321,7 @@ function prepareTransactionOutputs (outputs, _async) {
       )).then((outDerivation) => {
         return Promise.resolve(derivePublicKey(outDerivation, i, output.keys.publicSpendKey))
       }).then((outEphemeralPub) => {
-        return({
+        return ({
           amount: output.amount,
           target: {
             data: outEphemeralPub
@@ -1329,7 +1329,7 @@ function prepareTransactionOutputs (outputs, _async) {
           type: 'txout_to_key'
         })
       })
-    });
+    })
   } else {
     for (var i = 0; i < outputs.length; i++) {
       var output = outputs[i]
@@ -1357,7 +1357,7 @@ function prepareTransactionOutputs (outputs, _async) {
     return {
       transactionKeys,
       outputs: Promise.all(promises).then((outputs) => {
-        return outputs;
+        return outputs
       })
     }
   }

--- a/index.js
+++ b/index.js
@@ -597,15 +597,18 @@ class CryptoNote {
   }
 
   createTransactionAsync (ourKeys, newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime) {
-    var tx = this.createTransactionStructure(ourKeys, newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime, true)
-    var serializedTransaction = serializeTransaction(tx)
-    var txnHash = cnFastHash(serializedTransaction)
+    return this.createTransactionStructure(
+      ourKeys, newOutputs, ourOutputs, randomOuts, mixin, feeAmount, paymentId, unlockTime, true
+    ).then((tx) => {
+      var serializedTransaction = serializeTransaction(tx)
+      var txnHash = cnFastHash(serializedTransaction)
 
-    return {
-      transaction: tx,
-      rawTransaction: serializedTransaction,
-      hash: txnHash
-    }
+      return {
+        transaction: tx,
+        rawTransaction: serializedTransaction,
+        hash: txnHash
+      }
+    })
   }
 
   serializeTransaction (transaction) {


### PR DESCRIPTION
Which both runs asynchronously, and supports user functions that return promises.

Also.. removed the `ourKeys` parameter, which is not used anywhere.

From my testing, both code paths work correctly. Furthermore, if you call createTransactionAsync(), with user provided *non* async functions, it will still work.