### PR TITLE
Fix ordering of user provided generateKeyDerivation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1449,7 +1449,7 @@ function generateKeyDerivation (transactionPublicKey, privateViewKey) {
   }
 
   if (userCryptoFunctions.generateKeyDerivation) {
-    return userCryptoFunctions.generateKeyDerivation(privateViewKey, transactionPublicKey)
+    return userCryptoFunctions.generateKeyDerivation(transactionPublicKey, privateViewKey)
   } else if (TurtleCoinCrypto) {
     return TurtleCoinCrypto.generateKeyDerivation(privateViewKey, transactionPublicKey)
   } else {


### PR DESCRIPTION
It's a little confusing if the callback is not the same order as everywhere else.